### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "type": "git",
     "url": "git://github.com/boo1ean/mersenne-twister.git"
   },
+  "files": ["src"],
   "keywords": [
     "random",
     "mersenne",


### PR DESCRIPTION
Prevents `test`, `.travis.yml`, and `Makefile` from being published to NPM.